### PR TITLE
Update gamma trajectory logic and tests

### DIFF
--- a/mechafil_jax/locking.py
+++ b/mechafil_jax/locking.py
@@ -227,23 +227,56 @@ def get_day_schedule_pledge_release(
 
 
 # Creates the trajectory of the gamma smoothing function for FIP-81 activation
-def create_gamma_trajectory(current_date: np.datetime64, 
-                            forecast_length_days: int, 
-                            historical_lenght: int, 
-                            ramp_len_days=365):
-
-    historical_gamma = jnp.ones(historical_lenght) * 1.0
-    days_since_activation = (current_date - constants.FIP81_ACTIVATION_DATE).days
-
+# TODO: lock target, shall I include it here?
+def create_gamma_trajectory(
+    current_date: np.datetime64,
+    forecast_length_days: int,
+    historical_length: int,
+    ramp_len_days: int = 365,
+):
+    activation_date = np.datetime64(constants.FIP81_ACTIVATION_DATE, "D")
+    current_date = np.datetime64(current_date, "D")
+    
+    # Calculate start_date from current_date and historical_length
+    start_date = current_date - np.timedelta64(historical_length, "D")
+    
+    # Ramp slope
     gamma_slope = (1.0 - constants.FIP81_GAMMA_TARGET) / ramp_len_days
-    current_gamma = 1.0 - gamma_slope * days_since_activation
 
-    remaining_days = ramp_len_days - days_since_activation
-    v1 = jnp.linspace(current_gamma, constants.FIP81_GAMMA_TARGET, remaining_days)
-    v2 = jnp.ones(forecast_length_days - remaining_days) * constants.FIP81_GAMMA_TARGET
-    gamma_trajectory = jnp.concatenate([v1, v2])
+    # Days since activation (can be negative if before activation)
+    days_since_activation = int((current_date - activation_date) / np.timedelta64(1, "D"))
 
-    gamma_vec = jnp.concatenate(
-        [historical_gamma, gamma_trajectory]
-    )
+    # Historical gamma - account for FIP-81 activation within historical period
+    historical_gamma_list = []
+    for i in range(historical_length):
+        day_date = start_date + np.timedelta64(i, "D")
+        days_since_activation_hist = int((day_date - activation_date) / np.timedelta64(1, "D"))
+        
+        if days_since_activation_hist < 0:
+            gamma_val = 1.0
+        else:
+            gamma_val = max(1.0 - gamma_slope * days_since_activation_hist, constants.FIP81_GAMMA_TARGET)
+        
+        historical_gamma_list.append(gamma_val)
+    
+    historical_gamma = jnp.array(historical_gamma_list)
+
+    # If still before activation → gamma stays at 1.0
+    if days_since_activation < 0:
+        gamma_trajectory = jnp.ones(forecast_length_days)
+    else:
+        current_gamma = max(1.0 - gamma_slope * days_since_activation, constants.FIP81_GAMMA_TARGET)
+
+        # Remaining ramp days (non-negative)
+        remaining_days = max(ramp_len_days - days_since_activation, 0)
+
+        if remaining_days > 0:
+            v1 = jnp.linspace(current_gamma, constants.FIP81_GAMMA_TARGET, remaining_days)
+            v2 = jnp.ones(forecast_length_days - remaining_days) * constants.FIP81_GAMMA_TARGET
+            gamma_trajectory = jnp.concatenate([v1, v2])
+        else:
+            # Already past ramp end
+            gamma_trajectory = jnp.ones(forecast_length_days) * constants.FIP81_GAMMA_TARGET
+
+    gamma_vec = jnp.concatenate([historical_gamma, gamma_trajectory])
     return gamma_vec

--- a/test/test_fip81_gamma_trajectory.py
+++ b/test/test_fip81_gamma_trajectory.py
@@ -16,54 +16,89 @@ class TestFip81GammaTrajectory(unittest.TestCase):
         """
         Comprehensive test for FIP81 gamma trajectory generation covering:
         1. Basic trajectory structure and values
-        2. Edge cases and boundary conditions  
+        2. Edge cases and boundary conditions
         3. Specific known value verification
         4. Mathematical properties and constants
         5. Different ramp length scenarios
         """
-        
+
         # =============================================================================
         # PART 1: Basic trajectory test
         # =============================================================================
         print("\n=== PART 1: Basic Trajectory Test ===")
-        
+
         # Test parameters - using known dates for reproducible results
         current_date = date(2025, 1, 1)  # ~41 days after FIP81 activation
-        forecast_length_days = 400  # Make sure this is longer than remaining ramp days
+        forecast_length_days = 400       # Make sure this is longer than remaining ramp days
         historical_length = 30
-        ramp_len_days = 365  # Default ramp length
-        
+        ramp_len_days = 365              # Default ramp length
+
         # Calculate expected values manually
         days_since_activation = (current_date - constants.FIP81_ACTIVATION_DATE).days
         gamma_slope = (1.0 - constants.FIP81_GAMMA_TARGET) / ramp_len_days
         current_gamma = 1.0 - gamma_slope * days_since_activation
         remaining_days = ramp_len_days - days_since_activation
-        
+
         # Call library function
         gamma_vec = create_gamma_trajectory(
             current_date, forecast_length_days, historical_length, ramp_len_days
         )
-        
+
         # Test structure: historical + forecast
         expected_total_length = historical_length + forecast_length_days
         self.assertEqual(len(gamma_vec), expected_total_length)
-        
-        # Test historical period (should all be 1.0)
+
+        # -------------------------------------------------------------------------
+        # Historical part
+        # -------------------------------------------------------------------------
         historical_part = gamma_vec[:historical_length]
-        expected_historical = jnp.ones(historical_length) * 1.0
+
+        start_date = current_date - timedelta(days=historical_length)
+        expected_historical = []
+        for i in range(historical_length):
+            day_date = start_date + timedelta(days=i)
+            days_since_activation_hist = (day_date - constants.FIP81_ACTIVATION_DATE).days
+            if days_since_activation_hist < 0:
+                gamma_val = 1.0
+            else:
+                gamma_val = max(
+                    1.0 - gamma_slope * days_since_activation_hist,
+                    constants.FIP81_GAMMA_TARGET,
+                )
+            expected_historical.append(gamma_val)
+
+        expected_historical = jnp.array(expected_historical)
         np.testing.assert_array_almost_equal(historical_part, expected_historical, decimal=6)
-        
-        # Test forecast period structure
+
+        # -------------------------------------------------------------------------
+        # Forecast part
+        # -------------------------------------------------------------------------
         forecast_part = gamma_vec[historical_length:]
-        if remaining_days > 0:
+        if days_since_activation < 0:
+            # Before activation → all ones
+            expected_forecast = jnp.ones(forecast_length_days)
+            np.testing.assert_array_almost_equal(forecast_part, expected_forecast, decimal=6)
+
+        elif remaining_days > 0:
+            # Still ramping
+            expected_ramp = jnp.linspace(
+                max(current_gamma, constants.FIP81_GAMMA_TARGET),
+                constants.FIP81_GAMMA_TARGET,
+                remaining_days,
+            )
             ramp_part = forecast_part[:remaining_days]
-            expected_ramp = jnp.linspace(current_gamma, constants.FIP81_GAMMA_TARGET, remaining_days)
             np.testing.assert_array_almost_equal(ramp_part, expected_ramp, decimal=6)
-            
+
             if forecast_length_days > remaining_days:
                 constant_part = forecast_part[remaining_days:]
                 expected_constant = jnp.ones(forecast_length_days - remaining_days) * constants.FIP81_GAMMA_TARGET
                 np.testing.assert_array_almost_equal(constant_part, expected_constant, decimal=6)
+
+        else:
+            # Ramp already finished
+            expected_forecast = jnp.ones(forecast_length_days) * constants.FIP81_GAMMA_TARGET
+            np.testing.assert_array_almost_equal(forecast_part, expected_forecast, decimal=6)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Fix FIP-81 Gamma Trajectory Discontinuity

## Summary

This PR fixes a critical discontinuity bug in the FIP-81 gamma trajectory calculation that was causing jumps in `day_pledge_per_QAP` at the historical/forecast transition boundary.

## Problem

The original `create_gamma_trajectory()` function incorrectly set all historical gamma values to 1.0, regardless of whether FIP-81 had been activated during the historical period. This created a discontinuity at the current date when:

- **Historical period**: `gamma = 1.0` (flat, incorrect)
- **Current date**: `gamma = calculated_value` (could be ~0.7 if well into ramp period)
- **Jump magnitude**: Up to 0.3 difference in gamma values

This discontinuity propagated through the consensus pledge calculation, causing artificial jumps in key metrics like `day_pledge_per_QAP`.

## Solution

**Before:**
```python
# Always flat 1.0 for all history - WRONG!
historical_gamma = jnp.ones(historical_length) * 1.0
```

**After:**
```python
# Account for FIP-81 activation within historical period
historical_gamma_list = []
for i in range(historical_length):
    day_date = start_date + np.timedelta64(i, "D")
    days_since_activation_hist = int((day_date - activation_date) / np.timedelta64(1, "D"))
    
    if days_since_activation_hist < 0:
        gamma_val = 1.0  # Before activation
    else:
        gamma_val = max(1.0 - gamma_slope * days_since_activation_hist, constants.FIP81_GAMMA_TARGET)
    
    historical_gamma_list.append(gamma_val)

historical_gamma = jnp.array(historical_gamma_list)
```